### PR TITLE
Fix layout centering in courses and notices

### DIFF
--- a/src/Notices/notices.css
+++ b/src/Notices/notices.css
@@ -5,8 +5,8 @@ html, body {
 }
 
 body {
-    width: 1280px;
-    margin: 0 auto;
+    width: 100%;
+    margin: 0;
     font-family: 'Inter', sans-serif;
     background: linear-gradient(160deg, #06182A 0%, #0B1220 100%);
     color: #ffffff;
@@ -135,6 +135,21 @@ body {
     transition: background 0.3s ease, color 0.3s ease;
 }
 
+/* Contenedor principal para centrar todo el contenido */
+.page-wrapper {
+    width: 1280px;
+    margin: 0 auto;
+    position: relative;
+}
+
+/* Auth container para compatibilidad con partículas */
+.auth-container {
+    width: 1280px;
+    margin: 0 auto;
+    position: relative;
+    min-height: 100vh;
+}
+
 /* Asegurar transiciones suaves para el cambio de tema */
 .theme-transitioning {
     transition: all 0.3s ease !important;
@@ -159,7 +174,7 @@ body {
 .container {
     max-width: 1200px;
     margin: 0 auto;
-    padding: 0 var(--spacing-md);
+    padding: 0 20px;
 }
 
 /* ===== NAVIGATION BAR ===== */
@@ -186,7 +201,7 @@ body {
 .header-profile { 
     position: fixed !important; 
     top: 12px !important;
-    right: 16px !important; 
+    right: calc(50% - 640px + 20px) !important; /* Centrado respecto al contenedor de 1280px */
     left: auto !important;
     z-index: 1001; 
     width: 56px;
@@ -247,7 +262,7 @@ body {
 .bg-glow-global .header-profile {
     position: fixed !important;
     top: 12px !important;
-    right: 16px !important;
+    right: calc(50% - 640px + 20px) !important; /* Centrado respecto al contenedor de 1280px */
     left: auto !important;
     width: 56px;
     height: 56px;
@@ -258,7 +273,7 @@ body {
 .profile-menu { 
     position: fixed !important; 
     top: 76px !important; 
-    right: 16px !important; 
+    right: calc(50% - 640px + 20px) !important; /* Centrado respecto al contenedor de 1280px */
     left: auto !important;
     width: 260px; 
     background: rgba(10,16,28,.96); 
@@ -1070,6 +1085,10 @@ body[data-theme="light"] .bg-glow-global::before,
 /* ===== MAIN CONTENT ===== */
 .main-content {
     margin-top: 0;
+    width: 100%;
+    max-width: 1280px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 /* ===== HERO SECTION ===== */
@@ -1080,6 +1099,7 @@ body[data-theme="light"] .bg-glow-global::before,
     position: relative;
     overflow: hidden;
     border-bottom: 1px solid rgba(0, 102, 204, 0.1);
+    width: 100%;
 }
 
 .hero-container {
@@ -1174,6 +1194,7 @@ body[data-theme="light"] .bg-glow-global::before,
 .latest-section,
 .newsletter-section {
     padding: var(--spacing-xxl) 0;
+    width: 100%;
 }
 
 .section-header {

--- a/src/styles/courses.css
+++ b/src/styles/courses.css
@@ -91,14 +91,39 @@ html, body.courses-page {
     transition: background 0.3s ease, color 0.3s ease;
 }
 
+/* Contenedor principal para centrar todo el contenido */
+.page-wrapper {
+    width: 1280px;
+    margin: 0 auto;
+    position: relative;
+}
+
+/* Auth container para compatibilidad con partículas */
+.auth-container {
+    width: 1280px;
+    margin: 0 auto;
+    position: relative;
+    min-height: 100vh;
+}
+
 /* ===== Header fijo con navbar (para Mis Cursos) ===== */
-.catalog-header { position: fixed; top: 0; left: 0; right: 0; z-index: 1000; background: transparent; backdrop-filter: none; border-bottom: 0; }
+.catalog-header { 
+    position: fixed; 
+    top: 0; 
+    left: 50%;
+    transform: translateX(-50%);
+    width: 1280px;
+    z-index: 1000; 
+    background: transparent; 
+    backdrop-filter: none; 
+    border-bottom: 0; 
+}
 .catalog-header .container { display:flex; align-items:center; justify-content:center; gap:12px; padding: 10px 16px; min-height: 60px; position: relative; }
 .catalog-header .course-tabs { margin: 0; width: min(750px, 95vw); background: rgba(20,30,45,0.95); border: 1px solid rgba(68,229,255,0.15); box-shadow: 0 12px 40px rgba(0,0,0,0.3), 0 0 0 1px rgba(68,229,255,0.1) inset; backdrop-filter: blur(20px); border-radius: 20px; }
 .catalog-header .header-profile {
     position: fixed;
     top: 12px;
-    right: 20px;
+    right: calc(50% - 640px + 20px); /* Centrado respecto al contenedor de 1280px */
     transform: none;
     width: 56px;
     height: 56px;
@@ -110,7 +135,20 @@ html, body.courses-page {
     z-index: 1002;
 }
 .catalog-header .header-profile img { width: 100%; height: 100%; object-fit: cover; display: block; }
-.profile-menu { position: fixed; top: 72px; right: 20px; width: 240px; background: rgba(10,16,28,.96); border:1px solid rgba(68,229,255,.18); border-radius: 12px; box-shadow: 0 18px 46px rgba(0,0,0,.45); backdrop-filter: blur(10px); display:none; z-index: 1002; overflow: hidden; }
+.profile-menu { 
+    position: fixed; 
+    top: 72px; 
+    right: calc(50% - 640px + 20px); /* Centrado respecto al contenedor de 1280px */
+    width: 240px; 
+    background: rgba(10,16,28,.96); 
+    border:1px solid rgba(68,229,255,.18); 
+    border-radius: 12px; 
+    box-shadow: 0 18px 46px rgba(0,0,0,.45); 
+    backdrop-filter: blur(10px); 
+    display:none; 
+    z-index: 1002; 
+    overflow: hidden; 
+}
 .profile-menu.show { display:block; }
 .profile-menu .pm-header { display:flex; align-items:center; gap:10px; padding:12px 14px; border-bottom:1px solid rgba(68,229,255,.12); }
 .profile-menu .pm-avatar { width:36px; height:36px; border-radius:50%; overflow:hidden; border:1px solid rgba(68,229,255,.25); }
@@ -126,16 +164,16 @@ html, body.courses-page {
 
 /* ===== CONTENIDO PRINCIPAL ===== */
 .courses-main {
-    max-width: 100%;
-    width: 100%;
-    margin: 0;
-    padding: 70px 0 0 0; /* espacio para header fijo */
+    width: 1280px;
+    margin: 0 auto;
+    padding: 70px 20px 20px 20px; /* espacio para header fijo y padding lateral */
 }
 
 .courses-container {
     display: flex;
     flex-direction: column;
     gap: 5px;
+    max-width: 100%;
 }
 
 /* ===== PESTAÑAS DE NAVEGACIÓN ===== */
@@ -159,7 +197,21 @@ html, body.courses-page {
 }
 
 /* Botón de perfil flotante para header global */
-.header-profile { position: fixed; top: 12px; right: 20px; z-index: 1001; width: 56px; height: 56px; border-radius: 50%; overflow: hidden; border: 2px solid rgba(68,229,255,.35); padding: 0; background: rgba(7,17,36,.4); cursor:pointer; display: block; }
+.header-profile { 
+    position: fixed; 
+    top: 12px; 
+    right: calc(50% - 640px + 20px); /* Centrado respecto al contenedor de 1280px */
+    z-index: 1001; 
+    width: 56px; 
+    height: 56px; 
+    border-radius: 50%; 
+    overflow: hidden; 
+    border: 2px solid rgba(68,229,255,.35); 
+    padding: 0; 
+    background: rgba(7,17,36,.4); 
+    cursor:pointer; 
+    display: block; 
+}
 .header-profile:hover { filter: brightness(1.05); }
 .header-profile img { width: 100%; height: 100%; object-fit: cover; display:block; }
 
@@ -326,6 +378,7 @@ html, body.courses-page {
     overflow: hidden;
     backdrop-filter: blur(20px);
     transition: all 0.3s ease;
+    max-width: 100%;
 }
 
 /* ===== BARRA DE BÚSQUEDA ===== */
@@ -333,7 +386,7 @@ html, body.courses-page {
     margin: 24px auto;
     position: relative;
     max-width: 600px;
-    padding: 0 16px;
+    padding: 0;
 }
 
 .search-wrapper {
@@ -822,6 +875,7 @@ html, body.courses-page {
     border-radius: 16px;
     padding: 24px;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+    max-width: 100%;
 }
 
 .reminder-icon {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Centers the layout of `courses.html` and `notices.html` for desktop view.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This resolves issue APR-291 where content was left-aligned, leaving a large empty space on the right. The fix ensures all content is centered within a 1280px canvas, applying a consistent solution similar to `cursos.html` by using a main wrapper with `width: 1280px` and `margin: 0 auto`, and repositioning fixed elements relative to this centered container. Mobile responsiveness remains unchanged.

---
Linear Issue: [APR-291](https://linear.app/aprende-y-aplica/issue/APR-291/urgente-corregir-centrado-de-layout-en-courseshtml-y-noticeshtml)

<a href="https://cursor.com/background-agent?bcId=bc-8ba2918e-782d-4c3b-908a-5446e14eef8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8ba2918e-782d-4c3b-908a-5446e14eef8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

